### PR TITLE
Fixed missing Url class issue; added new functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": ">=7.1.0",
         "bacon/bacon-qr-code": "^2.0",
-        "pragmarx/recovery": "^0.1.0",
+        "pragmarx/recovery": "^0.2.0",
         "pragmarx/google2fa-laravel": "^1.0"
     },
     "autoload": {

--- a/config/383project2fa.php
+++ b/config/383project2fa.php
@@ -50,4 +50,9 @@ return [
          */
         'hashing_algorithm' => PASSWORD_BCRYPT,
     ],
+
+    /** 
+     * Session key (page) to redirect to after login
+     */
+    'session_redirect_key' => 'nova.redirect',
 ];

--- a/config/383project2fa.php
+++ b/config/383project2fa.php
@@ -54,5 +54,5 @@ return [
     /** 
      * Session key (page) to redirect to after login
      */
-    'session_redirect_key' => 'nova.redirect',
+    'session_redirect' => 'nova.redirect',
 ];

--- a/src/Google2fa.php
+++ b/src/Google2fa.php
@@ -46,7 +46,9 @@ class Google2fa extends Tool
             $authenticator = app(Google2FAAuthenticator::class);
             $authenticator->login();
 
-            return response()->redirectTo(config('nova.path'));
+            if ($key = config('383project2fa.session_redirect')) $path = request()->session()->pull($key);
+
+            return response()->redirectTo($path ?? config('nova.path'));
         }
 
         $google2fa = new G2fa;
@@ -137,7 +139,9 @@ class Google2fa extends Tool
             $authenticator = app(Google2FAAuthenticator::class);
             $authenticator->login();
 
-            return response()->redirectTo(config('nova.path'));
+            if ($key = config('383project2fa.session_redirect')) $path = request()->session()->pull($key);
+
+            return response()->redirectTo($path ?? config('nova.path'));
         }
         $data['error'] = 'One time password is invalid.';
 

--- a/src/Support/Url.php
+++ b/src/Support/Url.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PragmaRX\Google2FAPhp\Support;
+
+class Url
+{
+    public static function generateGoogleQRCodeUrl($domain, $page, $queryParameters, $qrCodeUrl)
+    {
+        $url = $domain.
+                rawurlencode($page).
+                '?'.$queryParameters.
+                urlencode($qrCodeUrl);
+
+        return $url;
+    }
+}


### PR DESCRIPTION
Class "PragmaRX\Google2FA\Support\Url" was missing. Added from https://github.com/antonioribeiro/google2fa-php/blob/14205424bf2e41f3b88d1d7d2b5f41359f7140df/src/Support/Url.php

Added functionality to specify redirect url after successful login